### PR TITLE
Add read_all_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ bytes_read: bytes = \
     await aioserial_instance.read_async(size: int = 1)
 ```
 
+##### read_all_async
+
+```py
+bytes_read: bytes = \
+    await aioserial_instance.read_all_async()
+```
+
 ##### read_until_async
 
 ```py

--- a/packages/aioserial/aioserial.py
+++ b/packages/aioserial/aioserial.py
@@ -97,6 +97,15 @@ class AioSerial(serial.Serial):
                 await asyncio.shield(self._cancel_read_async())
                 raise
 
+    async def read_all_async(self) -> bytes:
+        async with self._read_lock:
+            try:
+                return await self.loop.run_in_executor(
+                    self._read_executor, self.read_all)
+            except asyncio.CancelledError:
+                await asyncio.shield(self._cancel_read_async())
+                raise
+
     async def read_until_async(
             self,
             expected: bytes = serial.LF,


### PR DESCRIPTION
This adds `read_all_async`, which can be a bit faster in some applications if you don't know how many bytes to expect.